### PR TITLE
Enable ELF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ echo -n -e "earlyprintk=ttyS0 console=ttyS0\x00" > cmdline_file
 qemu-system-x86_64 -bios "${COREBOOT_FILE}" -nographic -serial mon:stdio -m 2G -enable-kvm \
   -device loader,addr=0x40000000,file="${BZIMAGE_FILE}",force-raw=on \
   -device loader,addr=0x60000000,file="${INITRD_FILE}",force-raw=on \
-  -device loader,addr=0x10000000,file=./cmdline_file.txt,force-raw=on \
+  -device loader,addr=0x10000000,file=./cmdline_file,force-raw=on \
   -device loader,addr=0x20000000,data=$(stat --printf="%s" "${INITRD_FILE}"),data-len=4 \
   -fw_cfg opt/de.cyberus-technology/bzimage_addr,file=./bzimage_addr \
   -fw_cfg opt/de.cyberus-technology/initrd_addr,file=./initrd_addr \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ assumes that a qemu [fw_cfg](https://github.com/qemu/qemu/blob/master/docs/specs
 is available and obtains the exact memory addresses from this device. During the boot process, the
 payload inspects the following items in `fw_cfg`:
 
-- `opt/de.cyberus-technology/bzimage_addr`: (mandatory) the start address of the raw bzImage in
+- `opt/de.cyberus-technology/kernel_addr`: (mandatory) the start address of the raw bzImage in
   memory
 - `opt/de.cyberus-technology/initrd_addr`: (optional) the start address of the raw initrd image in
   memory
@@ -52,7 +52,7 @@ qemu-system-x86_64 -bios "${COREBOOT_FILE}" -nographic -serial mon:stdio -m 2G -
   -device loader,addr=0x60000000,file="${INITRD_FILE}",force-raw=on \
   -device loader,addr=0x10000000,file=./cmdline_file,force-raw=on \
   -device loader,addr=0x20000000,data=$(stat --printf="%s" "${INITRD_FILE}"),data-len=4 \
-  -fw_cfg opt/de.cyberus-technology/bzimage_addr,file=./bzimage_addr \
+  -fw_cfg opt/de.cyberus-technology/kernel_addr,file=./bzimage_addr \
   -fw_cfg opt/de.cyberus-technology/initrd_addr,file=./initrd_addr \
   -fw_cfg opt/de.cyberus-technology/cmdline_addr,file=./cmdline_addr \
   -fw_cfg opt/de.cyberus-technology/initrd_size_addr,file=./initrd_size_addr

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
-# Coreboot Linux Loader
+# Coreboot Kernel Loader
 
 This repository contains code for building a [coreboot](https://www.coreboot.org/) payload which
-directly boots into a linux image that is available in memory. It follows the Linux [x86 32-bit Boot
-Protocol](https://www.kernel.org/doc/html/latest/x86/boot.html#bit-boot-protocol). The payload
-assumes that a qemu [fw_cfg](https://github.com/qemu/qemu/blob/master/docs/specs/fw_cfg.txt) device
-is available and obtains the exact memory addresses from this device. During the boot process, the
-payload inspects the following items in `fw_cfg`:
+directly boots into a kernel that is available in memory.
 
-- `opt/de.cyberus-technology/kernel_addr`: (mandatory) the start address of the raw bzImage in
+Supported kernels are:
+
+* Linux kernel image. The boot follows the Linux [x86 32-bit Boot
+Protocol](https://www.kernel.org/doc/html/latest/x86/boot.html#bit-boot-protocol).
+* 32 bit ELF binary. The boot is [Multiboot](https://www.gnu.org/software/grub/manual/multiboot/multiboot.html) compliant.
+
+The payload assumes that a qemu [fw_cfg](https://github.com/qemu/qemu/blob/master/docs/specs/fw_cfg.txt) device is available and obtains the exact memory addresses from this device. During the boot process, the payload inspects the following items in `fw_cfg`:
+
+- `opt/de.cyberus-technology/kernel_addr`: (mandatory) the start address of the kernel in
   memory
 - `opt/de.cyberus-technology/initrd_addr`: (optional) the start address of the raw initrd image in
   memory
@@ -41,18 +45,18 @@ qemu to boot a linux kernel like this:
 # or strings, so we need to create simple files which contain the little-endian byte representation
 # of the respective addresses.
 
-echo -n -e "\x00\x00\x00\x40" > bzimage_addr
+echo -n -e "\x00\x00\x00\x40" > kernel_addr
 echo -n -e "\x00\x00\x00\x60" > initrd_addr
 echo -n -e "\x00\x00\x00\x20" > initrd_size_addr
 echo -n -e "\x00\x00\x00\x10" > cmdline_addr
 echo -n -e "earlyprintk=ttyS0 console=ttyS0\x00" > cmdline_file
 
 qemu-system-x86_64 -bios "${COREBOOT_FILE}" -nographic -serial mon:stdio -m 2G -enable-kvm \
-  -device loader,addr=0x40000000,file="${BZIMAGE_FILE}",force-raw=on \
+  -device loader,addr=0x40000000,file="${KERNEL_FILE}",force-raw=on \
   -device loader,addr=0x60000000,file="${INITRD_FILE}",force-raw=on \
   -device loader,addr=0x10000000,file=./cmdline_file,force-raw=on \
   -device loader,addr=0x20000000,data=$(stat --printf="%s" "${INITRD_FILE}"),data-len=4 \
-  -fw_cfg opt/de.cyberus-technology/kernel_addr,file=./bzimage_addr \
+  -fw_cfg opt/de.cyberus-technology/kernel_addr,file=./kernel_addr \
   -fw_cfg opt/de.cyberus-technology/initrd_addr,file=./initrd_addr \
   -fw_cfg opt/de.cyberus-technology/cmdline_addr,file=./cmdline_addr \
   -fw_cfg opt/de.cyberus-technology/initrd_size_addr,file=./initrd_size_addr

--- a/elf_boot.h
+++ b/elf_boot.h
@@ -1,0 +1,66 @@
+/* Copyright Cyberus Technology GmbH *
+ *        All rights reserved        */
+
+/* SPDX-License-Identifier: GPL-2.0-only  */
+
+#ifndef ELF_BOOT_H
+#define ELF_BOOT_H
+
+#include <libpayload.h>
+
+#define MULTIBOOT_BOOTLOADER_MAGIC 0x2BADB002
+
+// Required fields in the Multiboot information structure.
+struct mb_boot_information_required {
+    uint32_t flags;
+    uint32_t mem_lower;
+    uint32_t mem_upper;
+    uint32_t boot_device;
+    uint32_t cmdline;
+};
+
+enum multiboot_info {
+    FLAG_CMDLINE_BIT = 1 << 2,
+};
+
+const char ELF_MAGIC[] = {0x7f, 'E', 'L', 'F'};
+const uint16_t ELF_CLASS_32BIT = 1;
+const uint8_t ELF_TYPE_EXECUTABLE = 0x2;
+const uint8_t ELF_DATA_LITTLE_ENDIAN = 1;
+const uint8_t ELF_VERSION = 1;
+
+struct elf32_header {
+    uint32_t magic;
+    uint8_t class;
+    uint8_t data;
+    uint8_t version;
+    uint8_t osabi;
+    uint8_t abiversion;
+    uint8_t pad[7];
+    uint16_t type;
+    uint16_t machine;
+    uint32_t eversion;
+    uint32_t entry;
+    uint32_t phoff;
+    uint32_t shoff;
+    uint32_t flags;
+    uint16_t ehsize;
+    uint16_t phentsize;
+    uint16_t phnum;
+    uint16_t shentsize;
+    uint16_t shnum;
+    uint16_t shstrndx;
+};
+
+struct elf32_program_header {
+    uint32_t type;
+    uint32_t offset;
+    uint32_t vaddr;
+    uint32_t paddr;
+    uint32_t filesize;
+    uint32_t memsize;
+    uint32_t flags;
+    uint32_t align;
+};
+
+#endif

--- a/main.c
+++ b/main.c
@@ -110,57 +110,57 @@ void linux_boot(struct bzimage_params bzimage_params)
     char *linux_header_end = (char *)(bzimage_params.kernel_addr + 0x201);
     size_t linux_header_size = 0x202 + *linux_header_end - LINUX_HEADER_OFFSET;
 
-    struct linux_params *boot_params = malloc(sizeof(*boot_params));
-    memset(boot_params, 0, sizeof(*boot_params));
+    struct linux_params *linux_params = malloc(sizeof(*linux_params));
+    memset(linux_params, 0, sizeof(*linux_params));
 
-    die_on(LINUX_HEADER_OFFSET + linux_header_size > sizeof(*boot_params),
+    die_on(LINUX_HEADER_OFFSET + linux_header_size > sizeof(*linux_params),
            "Invalid linux header size");
 
-    memcpy((char *)boot_params + LINUX_HEADER_OFFSET,
+    memcpy((char *)linux_params + LINUX_HEADER_OFFSET,
            (const char *)(bzimage_params.kernel_addr + LINUX_HEADER_OFFSET),
            linux_header_size); // load header
 
-    die_on(boot_params->param_block_version < 0x0205,
+    die_on(linux_params->param_block_version < 0x0205,
            "Kernel does not support boot protocol >= 2.05\n");
     die_on(
-        !boot_params->relocatable_kernel,
+        !linux_params->relocatable_kernel,
         "Kernel is not relocatable. The Linux kernel must be built with CONFIG_RELOCATABLE=y\n");
-    die_on(bzimage_params.kernel_addr % boot_params->kernel_alignment != 0,
-           "Kernel needs to be aligned at 0x%x\n", boot_params->kernel_alignment);
+    die_on(bzimage_params.kernel_addr % linux_params->kernel_alignment != 0,
+           "Kernel needs to be aligned at 0x%x\n", linux_params->kernel_alignment);
 
     printf("Setting up E820 map\n");
     // Coreboot already obtained the memory map. Simply copy it over into the kernel params.
-    boot_params->e820_map_nr = lib_sysinfo.n_memranges;
+    linux_params->e820_map_nr = lib_sysinfo.n_memranges;
     for (int i = 0; i < lib_sysinfo.n_memranges; i++) {
-        boot_params->e820_map[i].addr = lib_sysinfo.memrange[i].base;
-        boot_params->e820_map[i].size = lib_sysinfo.memrange[i].size;
-        boot_params->e820_map[i].type = lib_sysinfo.memrange[i].type;
+        linux_params->e820_map[i].addr = lib_sysinfo.memrange[i].base;
+        linux_params->e820_map[i].size = lib_sysinfo.memrange[i].size;
+        linux_params->e820_map[i].type = lib_sysinfo.memrange[i].type;
     }
 
     // There is a maximum size for the command line, which could be obtained from the kernel
     // header if the boot protocol version is >= 2.06. We don't check anything here and
     // simply assume the user knows what they are doing.
     if (bzimage_params.cmdline_addr != 0) {
-        boot_params->cmd_line_ptr = bzimage_params.cmdline_addr;
+        linux_params->cmd_line_ptr = bzimage_params.cmdline_addr;
     }
 
     if (bzimage_params.initrd_addr != 0) {
-        boot_params->initrd_start = bzimage_params.initrd_addr;
-        boot_params->initrd_size = *(u32 *)bzimage_params.initrd_size_addr;
+        linux_params->initrd_start = bzimage_params.initrd_addr;
+        linux_params->initrd_size = *(u32 *)bzimage_params.initrd_size_addr;
 
-        die_on(boot_params->initrd_start + boot_params->initrd_size
-                   > boot_params->initrd_addr_max,
+        die_on(linux_params->initrd_start + linux_params->initrd_size
+                   > linux_params->initrd_addr_max,
                "Initrd area exceeds maximum initrd address as required by the kernel\n");
     }
 
     const uint8_t custom_loader_type = 0xFF;
-    boot_params->loader_type = custom_loader_type;
+    linux_params->loader_type = custom_loader_type;
 
     // According to the Linux boot protocol, we should set up a simple GDT here. Both 32-bit
     // and 64-bit Linux set their own GDT right after the entry point, and simply jumping to
     // the entry address works without any issues so far, so we're skipping this.
 
-    uint8_t setup_sects = boot_params->setup_hdr;
+    uint8_t setup_sects = linux_params->setup_hdr;
 
     if (setup_sects == 0) {
         setup_sects = 4;
@@ -173,8 +173,8 @@ void linux_boot(struct bzimage_params bzimage_params)
     die_on(entry_ptr_32bit < bzimage_params.kernel_addr,
            "32-bit entry pointer lies beyond 4G\n");
 
-    asm volatile("jmp *%[entry_ptr];" ::[entry_ptr] "r"(entry_ptr_32bit), "S"(boot_params),
-                 "m"(boot_params));
+    asm volatile("jmp *%[entry_ptr];" ::[entry_ptr] "r"(entry_ptr_32bit), "S"(linux_params),
+                 "m"(linux_params));
 
     __builtin_unreachable();
 }

--- a/main.c
+++ b/main.c
@@ -11,9 +11,20 @@
 #include <libpayload-config.h>
 #include <libpayload.h>
 
+void dump_memory_map()
+{
+    printf("Memory map:\n");
+    for (int i = 0; i < lib_sysinfo.n_memranges; i++) {
+        struct memrange *memrange = &lib_sysinfo.memrange[i];
+        printf("  Start: 0x%08llx, Size: 0x%08llx, Type: 0x%02x\n", memrange->base,
+               memrange->size, memrange->type);
+    }
+}
+
 static void die_on(const bool condition, const char *string, ...)
 {
     if (condition) {
+        dump_memory_map();
         va_list ptr;
         va_start(ptr, string);
         vprintf(string, ptr);

--- a/main.c
+++ b/main.c
@@ -251,6 +251,8 @@ void elf_boot(const struct boot_params params)
         // address because the ELF program may modify page tables to use a custom virtual memory
         // layout that matches the segment's vaddr.
         const uintptr_t dest_addr = (uintptr_t)current_program_header->paddr;
+        die_on(dest_addr == 0,
+               "Unsupported ELF kernel. ELF segment has physical address 0x0.\n");
 
         // Copy contents of the region from the ELF file.
         memcpy((void *)dest_addr, current_elf_segment_in_memory,

--- a/main.c
+++ b/main.c
@@ -23,10 +23,10 @@ static void die_on(bool condition, char *string, ...)
 }
 
 struct boot_params {
-    size_t kernel_addr;
-    size_t initrd_addr;
-    size_t initrd_size_addr;
-    size_t cmdline_addr;
+    uintptr_t kernel_addr;
+    uintptr_t initrd_addr;
+    uintptr_t initrd_size_addr;
+    uintptr_t cmdline_addr;
 };
 
 enum boot_protocol {
@@ -62,7 +62,7 @@ int main(void)
 // Identify the type of the kernel.
 static enum boot_protocol get_boot_protocol(struct boot_params params)
 {
-    size_t kernel_addr = params.kernel_addr;
+    uintptr_t kernel_addr = params.kernel_addr;
 
     die_on(kernel_addr == 0, "Did not find the address of kernel.\n");
 
@@ -180,7 +180,7 @@ void linux_boot(struct boot_params boot_params)
         setup_sects = 4;
     }
 
-    size_t entry_ptr_32bit = boot_params.kernel_addr + (setup_sects + 1) * 512;
+    uintptr_t entry_ptr_32bit = boot_params.kernel_addr + (setup_sects + 1) * 512;
 
     // An overflowing unsigned integer addition will simply wrap. Such an overflow can be
     // detected by checking whether the result is smaller than one of the original values.

--- a/main.c
+++ b/main.c
@@ -22,7 +22,7 @@ static void die_on(bool condition, char *string, ...)
 }
 
 struct bzimage_params {
-    size_t bzimage_addr;
+    size_t kernel_addr;
     size_t initrd_addr;
     size_t initrd_size_addr;
     size_t cmdline_addr;
@@ -54,13 +54,13 @@ int main(void)
 // Identify the type of the kernel.
 static enum boot_protocol get_boot_protocol(struct bzimage_params params)
 {
-    size_t bzimage_addr = params.bzimage_addr;
+    size_t kernel_addr = params.kernel_addr;
 
-    die_on(bzimage_addr == 0, "Did not find the address of kernel.\n");
+    die_on(kernel_addr == 0, "Did not find the address of kernel.\n");
 
     // Linux kernel supporting the "new" boot protocol have a magic number at a specific offset.
     // See https://www.kernel.org/doc/Documentation/x86/boot.txt.
-    if (memcmp((uint32_t *)(bzimage_addr + 0x202), "HdrS", 4) == 0) {
+    if (memcmp((uint32_t *)(kernel_addr + 0x202), "HdrS", 4) == 0) {
         return LINUX;
     }
 
@@ -70,13 +70,13 @@ static enum boot_protocol get_boot_protocol(struct bzimage_params params)
 static struct bzimage_params get_boot_params_from_fw_cfg()
 {
     struct bzimage_params params = {
-        .bzimage_addr = 0, .initrd_addr = 0, .initrd_size_addr = 0, .cmdline_addr = 0};
+        .kernel_addr = 0, .initrd_addr = 0, .initrd_size_addr = 0, .cmdline_addr = 0};
 
     uint16_t selector;
 
-    selector = fw_cfg_selector_for("opt/de.cyberus-technology/bzimage_addr");
+    selector = fw_cfg_selector_for("opt/de.cyberus-technology/kernel_addr");
     if (selector != 0) {
-        fw_cfg_get(selector, &params.bzimage_addr, sizeof(params.bzimage_addr));
+        fw_cfg_get(selector, &params.kernel_addr, sizeof(params.kernel_addr));
     }
 
     selector = fw_cfg_selector_for("opt/de.cyberus-technology/initrd_addr");
@@ -101,13 +101,13 @@ static struct bzimage_params get_boot_params_from_fw_cfg()
 void linux_boot(struct bzimage_params bzimage_params)
 {
     die_on(
-        bzimage_params.bzimage_addr == 0,
+        bzimage_params.kernel_addr == 0,
         "bzImage start address not found!\n"
         "The VMM does not offer a Linux kernel via fw-cfg. Is the relevant config option missing?\n");
 
-    printf("Loading Linux kernel from address: 0x%lx\n", bzimage_params.bzimage_addr);
+    printf("Loading Linux kernel from address: 0x%lx\n", bzimage_params.kernel_addr);
 
-    char *linux_header_end = (char *)(bzimage_params.bzimage_addr + 0x201);
+    char *linux_header_end = (char *)(bzimage_params.kernel_addr + 0x201);
     size_t linux_header_size = 0x202 + *linux_header_end - LINUX_HEADER_OFFSET;
 
     struct linux_params *boot_params = malloc(sizeof(*boot_params));
@@ -117,7 +117,7 @@ void linux_boot(struct bzimage_params bzimage_params)
            "Invalid linux header size");
 
     memcpy((char *)boot_params + LINUX_HEADER_OFFSET,
-           (const char *)(bzimage_params.bzimage_addr + LINUX_HEADER_OFFSET),
+           (const char *)(bzimage_params.kernel_addr + LINUX_HEADER_OFFSET),
            linux_header_size); // load header
 
     die_on(boot_params->param_block_version < 0x0205,
@@ -125,7 +125,7 @@ void linux_boot(struct bzimage_params bzimage_params)
     die_on(
         !boot_params->relocatable_kernel,
         "Kernel is not relocatable. The Linux kernel must be built with CONFIG_RELOCATABLE=y\n");
-    die_on(bzimage_params.bzimage_addr % boot_params->kernel_alignment != 0,
+    die_on(bzimage_params.kernel_addr % boot_params->kernel_alignment != 0,
            "Kernel needs to be aligned at 0x%x\n", boot_params->kernel_alignment);
 
     printf("Setting up E820 map\n");
@@ -166,11 +166,11 @@ void linux_boot(struct bzimage_params bzimage_params)
         setup_sects = 4;
     }
 
-    size_t entry_ptr_32bit = bzimage_params.bzimage_addr + (setup_sects + 1) * 512;
+    size_t entry_ptr_32bit = bzimage_params.kernel_addr + (setup_sects + 1) * 512;
 
     // An overflowing unsigned integer addition will simply wrap. Such an overflow can be
     // detected by checking whether the result is smaller than one of the original values.
-    die_on(entry_ptr_32bit < bzimage_params.bzimage_addr,
+    die_on(entry_ptr_32bit < bzimage_params.kernel_addr,
            "32-bit entry pointer lies beyond 4G\n");
 
     asm volatile("jmp *%[entry_ptr];" ::[entry_ptr] "r"(entry_ptr_32bit), "S"(boot_params),


### PR DESCRIPTION
Support passing ELF binaries as kernel.

So far, the loader expected that a Linux kernel is passed and followed the 32 bit Linux boot protocol. The loader supports now 32 bit ELF binaries as an alternative. If an ELF is provided, the loader follows the Multiboot protocol.

## Changes

* Detect whether an ELF or a Linux kernel is provided.
* Extract the ELF to main memory according to the ELF header.
* Prepare a Multiboot information structure.
* Embed the optional command line in the Multiboot information structure.
* Jump to the ELF's entry point.