### PR TITLE
Refactoring

### DIFF
--- a/main.c
+++ b/main.c
@@ -67,32 +67,30 @@ static enum boot_protocol get_boot_protocol(const struct boot_params params)
     return UNKNOWN;
 }
 
+// Try to read a firmware config value from the given key.
+//
+// Returns 0 if the key does not exist.
+static uintptr_t try_get_fw_cfg_ptr(const char *key)
+{
+    const uint16_t selector = fw_cfg_selector_for(key);
+    uintptr_t value = 0;
+
+    if (selector != 0) {
+        fw_cfg_get(selector, &value, sizeof(value));
+    }
+
+    return value;
+}
+
 static struct boot_params get_boot_params_from_fw_cfg()
 {
     struct boot_params params = {
-        .kernel_addr = 0, .initrd_addr = 0, .initrd_size_addr = 0, .cmdline_addr = 0};
+        .kernel_addr = try_get_fw_cfg_ptr("opt/de.cyberus-technology/kernel_addr"),
+        .initrd_addr = try_get_fw_cfg_ptr("opt/de.cyberus-technology/initrd_addr"),
+        .initrd_size_addr = try_get_fw_cfg_ptr("opt/de.cyberus-technology/initrd_size_addr"),
+        .cmdline_addr = try_get_fw_cfg_ptr("opt/de.cyberus-technology/cmdline_addr"),
+    };
 
-    uint16_t selector;
-
-    selector = fw_cfg_selector_for("opt/de.cyberus-technology/kernel_addr");
-    if (selector != 0) {
-        fw_cfg_get(selector, &params.kernel_addr, sizeof(params.kernel_addr));
-    }
-
-    selector = fw_cfg_selector_for("opt/de.cyberus-technology/initrd_addr");
-    if (selector != 0) {
-        fw_cfg_get(selector, &params.initrd_addr, sizeof(params.initrd_addr));
-    }
-
-    selector = fw_cfg_selector_for("opt/de.cyberus-technology/initrd_size_addr");
-    if (selector != 0) {
-        fw_cfg_get(selector, &params.initrd_size_addr, sizeof(params.initrd_size_addr));
-    }
-
-    selector = fw_cfg_selector_for("opt/de.cyberus-technology/cmdline_addr");
-    if (selector != 0) {
-        fw_cfg_get(selector, &params.cmdline_addr, sizeof(params.cmdline_addr));
-    }
     return params;
 }
 

--- a/main.c
+++ b/main.c
@@ -98,7 +98,7 @@ static struct boot_params get_boot_params_from_fw_cfg()
 
 
 // Check whether the given memory region is within a single usable coreboot memory region.
-bool is_in_usable_coreboot_memory_region(const struct memory_region region)
+static bool is_in_usable_coreboot_memory_region(const struct memory_region region)
 {
     for (int i = 0; i < lib_sysinfo.n_memranges; i++) {
         struct memrange *memrange = &lib_sysinfo.memrange[i];
@@ -121,7 +121,7 @@ bool is_in_usable_coreboot_memory_region(const struct memory_region region)
 
 // Linux boot follows the Linux x86 32-bit Boot Protocol
 // (https://www.kernel.org/doc/html/latest/x86/boot.html#bit-boot-protocol).
-void linux_boot(const struct boot_params boot_params)
+static void linux_boot(const struct boot_params boot_params)
 {
     die_on(
         boot_params.kernel_addr == 0,
@@ -208,7 +208,7 @@ void linux_boot(const struct boot_params boot_params)
 // 1. Extracts the ELF binary.
 // 2. Prepares Multiboot information (to pass the optional command line).
 // 3. Jumps to the extracted ELF's entry point.
-void elf_boot(const struct boot_params params)
+static void elf_boot(const struct boot_params params)
 {
     die_on(
         params.kernel_addr == 0,

--- a/main.c
+++ b/main.c
@@ -12,7 +12,7 @@
 #include <libpayload-config.h>
 #include <libpayload.h>
 
-void dump_memory_map()
+static void dump_memory_map()
 {
     printf("Memory map:\n");
     for (int i = 0; i < lib_sysinfo.n_memranges; i++) {

--- a/memory_region.h
+++ b/memory_region.h
@@ -1,0 +1,39 @@
+/* Copyright Cyberus Technology GmbH *
+ *        All rights reserved        */
+
+/* SPDX-License-Identifier: GPL-2.0-only  */
+
+#ifndef MEMORY_REGION_H
+#define MEMORY_REGION_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct memory_region {
+    uintptr_t addr;
+    size_t size;
+};
+
+// Returns true if two memory regions overlap.
+static inline bool memory_regions_overlap(const struct memory_region first,
+                                          const struct memory_region second)
+{
+    const struct memory_region lower = first.addr <= second.addr ? first : second;
+    const struct memory_region higher = first.addr <= second.addr ? second : first;
+
+    // Completely disjunct regions?
+    if (higher.addr >= lower.addr + lower.size) {
+        return false;
+    }
+
+    return true;
+}
+
+static inline bool memory_region_contains(const struct memory_region container,
+                                          const struct memory_region containee)
+{
+    return container.addr <= containee.addr
+           && ((container.addr + container.size) >= (containee.addr + containee.size));
+}
+
+#endif

--- a/memory_region.h
+++ b/memory_region.h
@@ -21,12 +21,8 @@ static inline bool memory_regions_overlap(const struct memory_region first,
     const struct memory_region lower = first.addr <= second.addr ? first : second;
     const struct memory_region higher = first.addr <= second.addr ? second : first;
 
-    // Completely disjunct regions?
-    if (higher.addr >= lower.addr + lower.size) {
-        return false;
-    }
-
-    return true;
+    // When the higher region is not "behind" the lower region, the regions overlap.
+    return higher.addr < lower.addr + lower.size;
 }
 
 static inline bool memory_region_contains(const struct memory_region container,


### PR DESCRIPTION
I took a swing at the loader implementation and (hopefully) improved some things:

- Move memory region functions into their own header `memory_region.h`.
- Reordered functions to avoid forward declarations.
- Mark every non-exported function static.
- Simplify `memory_region_contains` and `get_boot_params_from_fw_cfg`.

Besides the last point, every change should not impact functionality at all. 

I've tested this with our internal test suite.

Please review commit-by-commit.