### PR TITLE
Require Linux boot protocol 2.10 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ directly boots into a kernel that is available in memory.
 Supported kernels are:
 
 * Linux kernel image. The boot follows the Linux [x86 32-bit Boot
-Protocol](https://www.kernel.org/doc/html/latest/x86/boot.html#bit-boot-protocol).
+Protocol](https://www.kernel.org/doc/html/latest/x86/boot.html#bit-boot-protocol). We support kernels in bzImage format
+  that follow boot protocol version 2.10 and above (v2.6.31 or later).
 * 32 bit ELF binary. The boot is [Multiboot](https://www.gnu.org/software/grub/manual/multiboot/multiboot.html) compliant (version 1 only).
 
 The payload assumes that a qemu [fw_cfg](https://github.com/qemu/qemu/blob/master/docs/specs/fw_cfg.rst) device is available and obtains the exact memory addresses from this device. During the boot process, the payload inspects the following items in `fw_cfg`:

--- a/linux_params.h
+++ b/linux_params.h
@@ -15,6 +15,10 @@
 
 #define LINUX_HEADER_OFFSET 0x1f1
 
+// Macro that encodes the used Linux boot protocol version according to the spec.
+#define TO_LINUX_BOOT_HEADER_VERSION(major, minor) \
+    ((major) << 8 | (minor))
+
 #define E820MAX 32 /* number of entries in E820MAP */
 struct e820entry {
     uint64_t addr; /* start of memory segment */

--- a/main.c
+++ b/main.c
@@ -117,8 +117,13 @@ static bool is_in_usable_coreboot_memory_region(const struct memory_region regio
     return false;
 }
 
-// Linux boot follows the Linux x86 32-bit Boot Protocol
+// Boots the provided payload according to the Linux x86 32-bit Boot Protocol
 // (https://www.kernel.org/doc/html/latest/x86/boot.html#bit-boot-protocol).
+//
+// Only bzImage Linux kernels are supported.
+//
+// We require Linux boot protocol 2.10 and above (v2.6.31 or later) as we read boot information
+// from the kernel image introduced with that version.
 static void linux_boot(const struct boot_params boot_params)
 {
     die_on(
@@ -130,6 +135,9 @@ static void linux_boot(const struct boot_params boot_params)
 
     // Print relevant information about how the Linux kernel would like to be booted
     const struct linux_params *const l_params = (const struct linux_params *const) boot_params.kernel_addr;
+    die_on(l_params->param_block_version < TO_LINUX_BOOT_HEADER_VERSION(2, 10),
+           "Kernel too old. Doesn't support boot protocol >= 2.10\n");
+
     printf("Info from Linux Boot Protocol Header:\n");
     printf("  kernel_alignment: 0x%x\n", l_params->kernel_alignment);
     printf("  relocatable_kernel: %s\n", l_params->relocatable_kernel ? "true" : "false");
@@ -150,8 +158,6 @@ static void linux_boot(const struct boot_params boot_params)
            (const char *)(boot_params.kernel_addr + LINUX_HEADER_OFFSET),
            linux_header_size); // load header
 
-    die_on(linux_params->param_block_version < 0x0205,
-           "Kernel does not support boot protocol >= 2.05\n");
     die_on(
         !linux_params->relocatable_kernel,
         "Kernel is not relocatable. The Linux kernel must be built with CONFIG_RELOCATABLE=y\n");


### PR DESCRIPTION
We require Linux boot protocol version 2.10 and above since bbcb93ba
because we access boot information from the boot image only available
since that version.