### PR TITLE
loader: fix multiboot1 ELF loading

### DIFF
--- a/main.c
+++ b/main.c
@@ -275,6 +275,10 @@ static void elf_boot(const struct boot_params params)
         const uint8_t *current_elf_segment_in_memory =
             elf_addr_in_memory + current_program_header->offset;
 
+        if (current_program_header->type != 1 /* not LOAD segment */) {
+            continue;
+        }
+
         printf(
             "Loading ELF segment (type 0x%x, offset 0x%x, vaddr 0x%x, paddr 0x%x, filesize 0x%x, memsize 0x%x)\n",
             current_program_header->type, current_program_header->offset,

--- a/main.c
+++ b/main.c
@@ -290,7 +290,7 @@ static void elf_boot(const struct boot_params params)
         // virtual memory layout that matches the segment's vaddr.
         const struct memory_region elf_region = {
             .addr = (uintptr_t)current_program_header->paddr,
-            .size = current_program_header->filesize + current_program_header->memsize};
+            .size = current_program_header->memsize};
         die_on(elf_region.addr == 0,
                "Unsupported ELF kernel. ELF segment has physical address 0x0.\n");
 


### PR DESCRIPTION
Fix a bug in the loader where the loader did weird stuff when 
- filesize > memsize
- a non-LOAD segment is loaded into memory